### PR TITLE
hardenzheng-前端-轮播组件

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,7 @@
 .App {
   text-align: center;
   position: relative;
+  height: 100%;
 }
 
 .title {
@@ -11,4 +12,19 @@
 .text {
   font-size: 28px;
   font-weight: 400;
+}
+
+html{
+  height: 100%;
+  width: 100%;
+}
+
+body{
+  height: 100%;
+  width: 100%;
+}
+
+#root{
+  width: 100%;
+  height: 100%;
 }

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,43 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/Get arPods/i);
-  expect(linkElement).toBeInTheDocument();
+// it('renders learn react link', () => {
+//     const { getByText } = render(<App />);
+//     const linkElement = getByText(/Get arPods/i);
+//     expect(linkElement).toBeInTheDocument();
+// });
+
+// 测试是否渲染了正确数目的progress
+it('render number of progress correct', ()=>{
+    let renderDom = render(<App/>)
+  
+    const progresses = renderDom.container.getElementsByClassName('progress_inner')
+
+    expect(progresses.length).toBe(3)
+})
+
+// 测试进度条是否能切换
+it('render progress change', () => {
+    let renderDom = render(<App />)
+    const progresses = renderDom.container.getElementsByClassName('progress_inner')
+
+    expect(progresses[0].className === "progress_inner progress_change" && 
+            progresses[1].className === "progress_inner " &&
+            progresses[2].className === "progress_inner ").toBe(true)
+
+    fireEvent.animationEnd(progresses[0])
+    expect(progresses[0].className === "progress_inner " && 
+            progresses[1].className === "progress_inner progress_change" &&
+            progresses[2].className === "progress_inner ").toBe(true)
+
+    fireEvent.animationEnd(progresses[1])
+    expect(progresses[0].className === "progress_inner " && 
+            progresses[1].className === "progress_inner " &&
+            progresses[2].className === "progress_inner progress_change").toBe(true)
+    
+    fireEvent.animationEnd(progresses[2])
+    expect(progresses[0].className === "progress_inner progress_change" && 
+            progresses[1].className === "progress_inner " &&
+            progresses[2].className === "progress_inner ").toBe(true)
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,6 +4,6 @@ import App from './App';
 
 test('renders learn react link', () => {
   const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
+  const linkElement = getByText(/Get arPods/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,64 @@
-import React from "react";
-import "./App.css";
+import React from 'react';
+import Carousel from './Carousel';
+import Card, { CardProps } from './Card';
+import './App.css';
+import './Card/index.css'
+
+const cardsData : CardProps[] = [
+  {
+    theKey: 'iphone',
+    imgUrl: require('./assets/iphone.png'),
+    titles:[
+        'xPhone',
+    ],
+    details:[
+      'Lots to love. Less to spend.',
+      'Starting at $399'
+    ],
+    styles:{
+      fontColor: '#FFFFFF',
+      bgColor: '#101010'
+    } 
+  },
+  {
+    theKey: 'tablet',
+    imgUrl: require('./assets/tablet.png'),
+    titles:[
+      'Tablet',
+    ],
+    details:[
+      'Just the right amount of everything.'
+    ],
+    styles:{
+        fontColor: '#000000',
+        bgColor: '#FAFAFA'
+      }
+  },
+  {
+    theKey: 'airPods',
+    imgUrl: require('./assets/airpods.png'),
+    titles:[
+      'Buy a Tablet or xPhone for college.',
+      'Get arPods.'
+    ],
+    details:[
+    ],
+    styles:{
+      fontColor:'#000000',
+      bgColor: '#F2F2F4'
+    }
+  }
+]
 
 function App() {
-  return <div className="App">{/* write your component here */}</div>;
+  return <div className="App">
+    <Carousel stayDuration={2000} switchDuration={300}>
+      {cardsData.map((v)=>{
+        return <Card key={v.theKey} theKey={v.theKey} imgUrl={v.imgUrl} titles={v.titles} details={v.details} styles={v.styles}/>
+      })}
+      {/* <div style={{width: '100%', height: '100%', backgroundColor: '#FF0000', flexShrink: 0}}>888</div> */}
+    </Carousel>
+  </div>;
 }
 
 export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,7 @@ const cardsData : CardProps[] = [
     ],
     details:[
       'Lots to love. Less to spend.',
-      'Starting at $399'
+      'Starting at $399.'
     ],
     styles:{
       fontColor: '#FFFFFF',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,7 +56,6 @@ function App() {
       {cardsData.map((v)=>{
         return <Card key={v.theKey} theKey={v.theKey} imgUrl={v.imgUrl} titles={v.titles} details={v.details} styles={v.styles}/>
       })}
-      {/* <div style={{width: '100%', height: '100%', backgroundColor: '#FF0000', flexShrink: 0}}>888</div> */}
     </Carousel>
   </div>;
 }

--- a/frontend/src/Card/index.css
+++ b/frontend/src/Card/index.css
@@ -1,0 +1,15 @@
+.card{
+    width: 100%;
+    height: 100%;
+    flex-shrink: 0;
+
+    background-position: center;
+    background-size: auto 100%;
+    background-repeat: no-repeat;
+}
+
+.texts_wrapper{
+    width: 100%;
+    height: 100%;
+    padding-top: 10%;
+}

--- a/frontend/src/Card/index.tsx
+++ b/frontend/src/Card/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import "./index.css"
+
+
+export interface CardProps{
+    theKey: string         // key
+    imgUrl: string     // 图片url
+    titles: string[]    // 标题
+    details: string[]   // 详情
+    styles:{            // 样式合集    
+        fontColor: string
+        bgColor: string
+    }
+}
+
+function Card({
+    imgUrl, titles, details, styles
+}:CardProps){
+
+    return (<div className="card" style={{backgroundImage: `url(${imgUrl})`, color: styles.fontColor, backgroundColor: styles.bgColor}}>
+        <div className='texts_wrapper'>
+            {titles.map((title, index) =>{
+                return <div key={`t${index}`} className='title'>{title}</div>
+            })}
+            {details.map((detail, index)=>{
+                return <div key={`d${index}`}  className='text'>{detail}</div>
+            })}
+        </div>
+    </div>)
+}
+
+export default Card

--- a/frontend/src/Carousel/index.css
+++ b/frontend/src/Carousel/index.css
@@ -4,7 +4,6 @@
 
     overflow: hidden;
     position: relative;
-    background-color: aqua;
 }
 
 .goodlist{
@@ -17,9 +16,6 @@
     align-items: center;
 
     transition: all ease;
-
-    color: white;
-    background-color: gray;
 }
 
 .progress_list{

--- a/frontend/src/Carousel/index.css
+++ b/frontend/src/Carousel/index.css
@@ -1,0 +1,70 @@
+.root{
+    width: 100%;
+    height: 100%;
+
+    overflow: hidden;
+    position: relative;
+    background-color: aqua;
+}
+
+.goodlist{
+    width: 100%;
+    height: 100%;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+
+    transition: all ease;
+
+    color: white;
+    background-color: gray;
+}
+
+.progress_list{
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 28px;
+    margin: auto;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+.progress{
+    width: 50px;
+    height: 4px;
+    margin-left: 4px;
+    margin-right: 4px;
+
+    background-color: grey;
+    border-radius: 4px;
+}
+
+.progress_inner{
+    width: 0%;
+    height: 100%;
+
+    background-color: aliceblue;
+    border-radius: 4px;
+}
+
+@keyframes progress{
+    from {
+        width: 0%;
+    }
+    to{
+        width: 100%;
+    }
+}
+
+.progress_change{
+    animation-name: progress;
+    /* animation-duration: 2s;   以外部传入为准 */
+    animation-iteration-count: 1;
+    animation-timing-function: linear;
+    animation-fill-mode: backwards;
+}

--- a/frontend/src/Carousel/index.tsx
+++ b/frontend/src/Carousel/index.tsx
@@ -16,23 +16,35 @@ function Carousel({stayDuration, switchDuration, size, children} : CarouselProps
     const refProgressList = useRef(null)
     const [_curIndex, setCurIndex] = useState(0)
 
-    // 进度条
+    // 所有进度条添加动画监听 和 回收函数
     useEffect(()=>{
         const len = React.Children.count(children)
-        const target = getCurrent(refProgressList).childNodes[_curIndex].childNodes[0]
 
-        // 监听进度条动画结束
-        target.onanimationend = ()=>{
-            target.className = "progress_inner"
-            target.onanimationend = null
+        const progresses = getCurrent(refProgressList).childNodes
+        for(let i = 0; i < progresses.length; i++){
+            const current = progresses[i].childNodes[0]
+            current.onanimationend = ()=>{
+                current.className = "progress_inner"
 
-            const nextIndex = (_curIndex + 1) % len
-            setCurIndex(nextIndex)
+                setCurIndex((oldIndex)=> (oldIndex + 1) % len) 
+            }
         }
+        return ()=>{
+            for(let i = 0; i < progresses.length; i++){
+                const current = progresses[i].childNodes[0]
+                current.onanimationend = null
+            }
+        }
+    },[children])
 
-        // 进度条添加动画
-        target.className += " progress_change"
-    },[_curIndex, children])
+    //给当前的progress添加动画
+    useEffect(()=>{
+        const len = React.Children.count(children)
+        if(_curIndex >= len)    return
+
+        const current = getCurrent(refProgressList).childNodes[_curIndex].childNodes[0]
+        current.className += " progress_change"
+    }, [_curIndex, children])
 
     function getCurrent(refValue: any){
         return refValue.current as any

--- a/frontend/src/Carousel/index.tsx
+++ b/frontend/src/Carousel/index.tsx
@@ -1,6 +1,6 @@
 
 import React, { ReactNode } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import './index.css'
 
 interface CarouselProps{
@@ -13,41 +13,11 @@ interface CarouselProps{
     children: ReactNode
 }
 function Carousel({stayDuration, switchDuration, size, children} : CarouselProps){
-    const refProgressList = useRef(null)
     const [_curIndex, setCurIndex] = useState(0)
+    const len = React.Children.count(children)
 
-    // 所有进度条添加动画监听 和 回收函数
-    useEffect(()=>{
-        const len = React.Children.count(children)
-
-        const progresses = getCurrent(refProgressList).childNodes
-        for(let i = 0; i < progresses.length; i++){
-            const current = progresses[i].childNodes[0]
-            current.onanimationend = ()=>{
-                current.className = "progress_inner"
-
-                setCurIndex((oldIndex)=> (oldIndex + 1) % len) 
-            }
-        }
-        return ()=>{
-            for(let i = 0; i < progresses.length; i++){
-                const current = progresses[i].childNodes[0]
-                current.onanimationend = null
-            }
-        }
-    },[children])
-
-    //给当前的progress添加动画
-    useEffect(()=>{
-        const len = React.Children.count(children)
-        if(_curIndex >= len)    return
-
-        const current = getCurrent(refProgressList).childNodes[_curIndex].childNodes[0]
-        current.className += " progress_change"
-    }, [_curIndex, children])
-
-    function getCurrent(refValue: any){
-        return refValue.current as any
+    const animationEndCallback = ()=>{
+        setCurIndex((oldIndex)=> (oldIndex + 1) % len) 
     }
 
     return (
@@ -57,11 +27,11 @@ function Carousel({stayDuration, switchDuration, size, children} : CarouselProps
             {children}
         </div>
 
-        <div ref={refProgressList} className="progress_list">
-            {React.Children.map(children, ()=>{
+        <div className="progress_list" onAnimationEnd={animationEndCallback}>
+            {React.Children.map(children, (child, index)=>{
                 return (
                 <div className="progress">
-                    <div className="progress_inner" style={{animationDuration: `${stayDuration / 1000}s`}}></div>
+                    <div className={`progress_inner ${_curIndex === index ? 'progress_change': ''}`} style={{animationDuration: `${stayDuration / 1000}s`}}></div>
                 </div>)
             })}
         </div>

--- a/frontend/src/Carousel/index.tsx
+++ b/frontend/src/Carousel/index.tsx
@@ -1,0 +1,59 @@
+
+import React, { ReactNode } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import './index.css'
+
+interface CarouselProps{
+    stayDuration: number           // milliseconds
+    switchDuration: number         // milliseconds
+    size?:{                         // width && height; default: 100% && 100%
+        width?: string
+        height?: string
+    }                          
+    children: ReactNode
+}
+function Carousel({stayDuration, switchDuration, size, children} : CarouselProps){
+    const refProgressList = useRef(null)
+    const [_curIndex, setCurIndex] = useState(0)
+
+    // 进度条
+    useEffect(()=>{
+        const len = React.Children.count(children)
+        const target = getCurrent(refProgressList).childNodes[_curIndex].childNodes[0]
+
+        // 监听进度条动画结束
+        target.onanimationend = ()=>{
+            target.className = "progress_inner"
+            target.onanimationend = null
+
+            const nextIndex = (_curIndex + 1) % len
+            setCurIndex(nextIndex)
+        }
+
+        // 进度条添加动画
+        target.className += " progress_change"
+    },[_curIndex, children])
+
+    function getCurrent(refValue: any){
+        return refValue.current as any
+    }
+
+    return (
+    <div className="root" style={{...size}}>
+        <div className="goodlist" 
+                style={{transitionDuration: `${switchDuration}ms`, transform: `translateX(-${_curIndex * 100}%)`}}>
+            {children}
+        </div>
+
+        <div ref={refProgressList} className="progress_list">
+            {React.Children.map(children, ()=>{
+                return (
+                <div className="progress">
+                    <div className="progress_inner" style={{animationDuration: `${stayDuration / 1000}s`}}></div>
+                </div>)
+            })}
+        </div>
+    </div>)
+}
+
+export default Carousel


### PR DESCRIPTION
## 完成功能
1. 轮播图基本功能
2. 轮播图的 页面展示时间和页面切换时间 支持自定义
3. 轮播图的大小支持自定义（即：一个页面里可以展示多个轮播图）
4. 轮播图的child可以任意添加，只需满足    width: 100%; height: 100%;flex-shrink: 0; 即可。
5. 写了2个测试用例

## 如何联系我
* 手机号：13530771226
* 邮箱：2821084381@qq.com